### PR TITLE
Update bleak dependency to allow versions >=1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neosmartblue.py"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Python library for controlling Neo Smart Blinds via BlueLink Bluetooth connection"
 authors = [
     {name = "ikifar2012", email = "ikifar2012@users.noreply.github.com"}
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "bleak ==1.0.1"
+    "bleak >=1.0.1"
 ]
 keywords = ["bluetooth", "ble", "smart blinds", "neo", "home automation"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "bleak ==1.1.0"
+    "bleak ==1.0.1"
 ]
 keywords = ["bluetooth", "ble", "smart blinds", "neo", "home automation"]
 classifiers = [


### PR DESCRIPTION
This pull request updates the package version and relaxes the dependency requirement for the `bleak` library to allow for greater compatibility.

Dependency and version updates:

* Updated the project version in `pyproject.toml` from `0.1.2` to `0.1.3`.
* Relaxed the `bleak` dependency requirement in `pyproject.toml` from an exact version (`==1.1.0`) to a minimum version (`>=1.0.1`).